### PR TITLE
Update Chewie version so composer recognizes the laravel/prompts dependency update.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "joetannenbaum/chewie",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "require": {
         "laravel/prompts": "0.x"
     },


### PR DESCRIPTION
I suspect the laravel/prompts version update to "0.x" [here](https://github.com/joetannenbaum/chewie/commit/dcf3405393c85fb4d92ad70b57574c0830456068) isn't being recognized by composer because the chewie version wasn't updated at the same time.

I'm trying to install aarondfrancis/solo, and composer is insisting on downgrading my  laravel/prompts version to 0.1.x