### PR TITLE
Add requirement for illuminate/collections which is used in various f…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "name": "joetannenbaum/chewie",
     "version": "0.1.9",
     "require": {
-        "laravel/prompts": "0.x"
+        "laravel/prompts": "0.x",
+        "illuminate/collections": "^10.0 || ^11.0"
     },
     "require-dev": {
         "pestphp/pest": "^2.33",


### PR DESCRIPTION
Add requirement for illuminate/collections which is used in various features

- Consumers of this package in Laravel applications will not notice this issue as they will already have collections available through Laravel
- However, use of this package is possible as a standalone dependency outside of Laravel and those users will need to have illuminate/collections to use the features provided